### PR TITLE
Bug fixes.

### DIFF
--- a/build-firmware.sh
+++ b/build-firmware.sh
@@ -24,10 +24,10 @@ else
         SUDO=""
 fi
 
-DIR=$(readlink -f $DIR)
+DIR=$(greadlink -f $DIR)
 
 # Make sure we're operating out of the FMK directory
-cd $(dirname $(readlink -f $0))
+cd $(dirname $(greadlink -f $0))
 
 # Order matters here!
 eval $(cat shared-ng.inc)

--- a/extract-firmware.sh
+++ b/extract-firmware.sh
@@ -46,7 +46,7 @@ fi
 Build_Tools
 
 # Get the size, in bytes, of the target firmware image
-FW_SIZE=$(ls -l "${IMG}" | cut -d' ' -f5)
+FW_SIZE=$(stat -f '%z' "${IMG}")
 
 # Create output directories
 mkdir -p "${DIR}/logs"


### PR DESCRIPTION
* Use stat instead of ls | cut for determining original file size.
* Use greadlink instead of readlink in build-firmware.sh.