### PR TITLE
Update check_for_upgrade.sh

### DIFF
--- a/check_for_upgrade.sh
+++ b/check_for_upgrade.sh
@@ -4,7 +4,7 @@ TMPNAME=`mktemp`
 SYSNAME=`uname`
 mkdir tmp
 cd tmp
-wget --quiet --timeout=4 --tries=1 https://firmware-mod-kit.googlecode.com/git/firmware_mod_kit_version.txt
+wget --quiet --timeout=4 --tries=1 https://raw.githubusercontent.com/cinquemb/firmware-mod-kit-osx/master/firmware_mod_kit_version.txt
 mv firmware_mod_kit_version.txt "$TMPNAME"
 cd .. && rm -rf tmp
 if [ ! -f "$TMPNAME" ]; then


### PR DESCRIPTION
Given that firmware-mod-kit has been put into archive by google, and you are maintaining the fork for OSX then we can refer to the firmware_mod_kit_version.txt that you are hosting if you are planning to upgrade to a newer version.